### PR TITLE
Update SmartLeds.h

### DIFF
--- a/src/SmartLeds.h
+++ b/src/SmartLeds.h
@@ -109,8 +109,8 @@ public:
         DPORT_CLEAR_PERI_REG_MASK( DPORT_PERIP_RST_EN_REG, DPORT_RMT_RST );
 
         PIN_FUNC_SELECT( GPIO_PIN_MUX_REG[ pin ], 2 );
-        gpio_matrix_out( static_cast< gpio_num_t >( pin ), RMT_SIG_OUT0_IDX + _channel, 0, 0 );
         gpio_set_direction( static_cast< gpio_num_t >( pin ), GPIO_MODE_OUTPUT );
+        gpio_matrix_out( static_cast< gpio_num_t >( pin ), RMT_SIG_OUT0_IDX + _channel, 0, 0 );
         initChannel( _channel );
 
         RMT.tx_lim_ch[ _channel ].limit = detail::MAX_PULSES;


### PR DESCRIPTION
"gpio_set_direction" (Smartleds.h,113) modifyes (recently?) the pin-matrix set one line before - so line 112 becomes ineffective.

Switching Line 113 and 112 will fix the problem.