### PR TITLE
Fix RGB <-> HSV conversion

### DIFF
--- a/examples/basicExample/basicExample.ino
+++ b/examples/basicExample/basicExample.ino
@@ -21,7 +21,7 @@ void showGradient() {
     hue++;
     // Use HSV to create nice gradient
     for ( int i = 0; i != LED_COUNT; i++ )
-        leds[ i ] = Hsv{ static_cast< uint8_t >( hue + 30 * i ), 255, 255 };
+        leds[ i ] = Hsv{ static_cast< uint16_t >( hue + 30 * i ), 255, 255 };
     leds.show();
     // Show is asynchronous; if we need to wait for the end of transmission,
     // we can use leds.wait(); however we use double buffered mode, so we

--- a/examples/basicExample/basicExample.ino
+++ b/examples/basicExample/basicExample.ino
@@ -16,12 +16,12 @@ void setup() {
   Serial.begin(9600);  
 }
 
-uint8_t hue;
+uint16_t hue;
 void showGradient() {
     hue++;
     // Use HSV to create nice gradient
     for ( int i = 0; i != LED_COUNT; i++ )
-        leds[ i ] = Hsv{ static_cast< uint16_t >( hue + 30 * i ), 255, 255 };
+        leds[ i ] = Hsv{ static_cast< uint16_t >( (hue + 30 * i) % 360 ), 255, 255 };
     leds.show();
     // Show is asynchronous; if we need to wait for the end of transmission,
     // we can use leds.wait(); however we use double buffered mode, so we

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -15,33 +15,33 @@ Rgb::Rgb( Hsv y ) {
     
     if (0 <= hPrime && hPrime < 1) {
         r = color;
-        g = static_cast<uint8_t>(x + 0.5);
+        g = static_cast<uint8_t>(x);
         b = 0;
     }
     else if (1 <= hPrime && hPrime < 2) {
-        r = static_cast<uint8_t>(x + 0.5);
+        r = static_cast<uint8_t>(x);
         g = color;
         b = 0;
     }
     else if(2 <= hPrime && hPrime < 3) {
         r = 0;
         g = color;
-        b = static_cast<uint8_t>(x + 0.5);
+        b = static_cast<uint8_t>(x);
     }
     else if(3 <= hPrime && hPrime < 4) {
         r = 0;
-        g = static_cast<uint8_t>(x + 0.5);
+        g = static_cast<uint8_t>(x);
         b = color;
     }
     else if(4 <= hPrime && hPrime < 5) {
-        r = static_cast<uint8_t>(x + 0.5);
+        r = static_cast<uint8_t>(x);
         g = 0;
         b = color;
     }
     else if(5 <= hPrime && hPrime < 6) {
         r = color;
         g = 0;
-        b = static_cast<uint8_t>(x + 0.5);
+        b = static_cast<uint8_t>(x);
     }
     else {
         r = 0;
@@ -94,9 +94,9 @@ Hsv::Hsv( Rgb r ) {
         hue = 360 + hue;
     }
     saturation *= 255;
-    h = static_cast<uint16_t>(hue + 0.5);
-    s = static_cast<uint8_t>(saturation + 0.5);
-    v = static_cast<uint8_t>(value + 0.5);
+    h = static_cast<uint16_t>(hue);
+    s = static_cast<uint8_t>(saturation);
+    v = static_cast<uint8_t>(value);
 }
 
 Hsv& Hsv::operator=( Rgb rgb ) {

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -93,11 +93,10 @@ Hsv::Hsv( Rgb r ) {
     if(hue < 0) {
         hue = 360 + hue;
     }
-    saturation *= 100;
+    saturation *= 255;
     h = static_cast<uint16_t>(hue + 0.5);
     s = static_cast<uint8_t>(saturation + 0.5);
     v = static_cast<uint8_t>(value + 0.5);
-
 }
 
 Hsv& Hsv::operator=( Rgb rgb ) {

--- a/src/Color.h
+++ b/src/Color.h
@@ -43,11 +43,12 @@ private:
 
 union Hsv {
     struct __attribute__ ((packed)) {
-        uint8_t h, s, v, _extra;
+        uint16_t h;
+        uint8_t s, v, _extra;
     };
     uint32_t value;
 
-    Hsv( uint8_t h, uint8_t s = 0, uint8_t v = 0 ) : h( h ), s( s ), v( v ), _extra( 0 ) {}
+    Hsv( uint16_t h, uint8_t s = 0, uint8_t v = 0 ) : h( h ), s( s ), v( v ), _extra( 0 ) {}
     Hsv( Rgb r );
     Hsv& operator=( Hsv h ) { swap( h ); return *this; }
     Hsv& operator=( Rgb rgb );


### PR DESCRIPTION
I was having some issues with the RGB / HSV conversion so I re-implemented those constructors using https://gist.github.com/fairlight1337/4935ae72bcbcc1ba5c72

There is a breaking change: HSV now takes `uint16_t` for `hue`
